### PR TITLE
Repo updates -- names in readme, https protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "suite2p"]
 	path = suite2p
-	url = git@github.com:alihaydaroglu/suite2p.git
+	url = https://github.com/alihaydaroglu/suite2p.git

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ## Installation
+If the cloning line doesn't work, try: git clone --recurse-submodules https://github.com/alihaydaroglu/suite3d
+
 ```
-git clone --recurse-submodules git@github.com:alihaydaroglu/s2p-lbm.git
+git clone --recurse-submodules git@github.com:alihaydaroglu/suite3d.git
 conda env create -f environment.yml
-conda activate s2p-lbm
-cd suite2p
+conda activate suite3d-gpu
+cd suite3d
 pip install -e .
 ```
 If installation gets stuck around "Solving Environment", you should use libmamba ([explanation](https://conda.github.io/conda-libmamba-solver/libmamba-vs-classic/)), install it using the [instructions here](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community). Also, set the conda channel priority to be strict: `conda config --set channel_priority strict`. It's important that you don't forget the `-e` in the pip command, this allows the suite2p installation to be editable.
@@ -22,7 +24,7 @@ Then, run the Demo notebook.
 If you want to only visualize results on your local laptop, you can install a lightweight script that doesn't have any of the computational dependencies. 
 
 ```
-git clone --recurse-submodules git@github.com:alihaydaroglu/s2p-lbm.git
+git clone --recurse-submodules git@github.com:alihaydaroglu/suite3d.git
 conda create -y -n s3d-vis -c conda-forge python=3.9
 conda activate s3d-vis
 pip install "napari[pyqt5]"


### PR DESCRIPTION
Just a few small updates. First - the README had outdated names in it, so I updated them to suite3d and suite3d-gpu.

Second- my github ssh key had expired and it prevented me from cloning the repo, since it's set up to use the SSH protocol (this is the case for the main repo, e.g. the install code block in the readme, and also for suite2p submodule in the .gitmodules file). Since this is ideally for many people to use, it might be nice to change this to the https protocol - this PR makes that edit in the .gitmodules file and also adds a line to the README saying to use https://.... if the git: one doesn't work. But maybe it would be better to simply use HTTPS as default? 