### PR TITLE
bugfixes, housekeeping, suggestions

### DIFF
--- a/suite3d/default_params.py
+++ b/suite3d/default_params.py
@@ -95,7 +95,7 @@ params = {
     # reference image paramaters
     "percent_contribute": 0.9,
     # percentage of frames which contribute to the reference image
-    "block_size": (128, 128),
+    "block_size": (128, 128),  # if you have lots of non-rigid movement, consider (64, 64)
     # size of a non-rigid block
     "sigma_reference": (1.45, 0),
     "smooth_sigma_reference": 1.15,

--- a/suite3d/iter_step.py
+++ b/suite3d/iter_step.py
@@ -7,6 +7,7 @@ from dask import array as darr
 import time
 from suite2p.registration import register
 from suite2p.registration import nonrigid
+from suite2p.registration.nonrigid import transform_data
 
 # from . import deepinterp as dp
 
@@ -871,7 +872,7 @@ def register_dataset_gpu(
                 if nonrigid:
                     # print("SHIFITNG: %d" % zidx)
                     # TODO migrate to suite3D?
-                    mov_shifted[zidx, idx0:idx1] = nonrigid.transform_data(
+                    mov_shifted[zidx, idx0:idx1] = transform_data(
                         mov_shifted_cpu[:, zidx],
                         nblocks,
                         xblock=xblocks,

--- a/suite3d/job.py
+++ b/suite3d/job.py
@@ -594,7 +594,6 @@ class Job:
 
         if mov is None:
             mov = self.get_registered_movie("registered_fused_data", "fused")
-            mov = self.get_registered_movie("registered_fused_data", "fused")
 
         self.save_params(copy_dir=corr_map_dir)
         self.corrmap = corrmap.calculate_corrmap(
@@ -613,10 +612,7 @@ class Job:
     def load_corr_map_results(self, parent_dir_name=None):
         files = ["max_img.npy", "mean_img.npy", "vmap.npy"]
         corrmap_dir_tag = "corrmap"
-        files = ["max_img.npy", "mean_img.npy", "vmap.npy"]
-        corrmap_dir_tag = "corrmap"
         if parent_dir_name is not None:
-            corrmap_dir_tag = parent_dir_name + "-corrmap"
             corrmap_dir_tag = parent_dir_name + "-corrmap"
         results = {}
         for file in files:
@@ -755,9 +751,6 @@ class Job:
             comb_dir_name = sweep_summary["comb_dir_names"][comb_idx]
             comb_params = sweep_summary["comb_params"][comb_idx]
             self.log("Running combination %02d/%02d" % (comb_idx + 1, n_combs), 0)
-            comb_dir_name = sweep_summary["comb_dir_names"][comb_idx]
-            comb_params = sweep_summary["comb_params"][comb_idx]
-            self.log("Running combination %02d/%02d" % (comb_idx + 1, n_combs), 0)
             self.params = comb_params
             corrmap_out = self.calculate_corr_map(
                 output_dir_name=comb_dir_name,
@@ -812,21 +805,16 @@ class Job:
             params_to_sweep, sweep_name, all_combinations=all_combinations
         )
         sweep_summary["sweep_type"] = "segmentation"
-        sweep_dir_path = sweep_summary["sweep_dir_path"]
         sweep_summary["results"] = []
-        combinations = sweep_summary["combinations"]
         sweep_summary["sweep_type"] = "segmentation"
         sweep_dir_path = sweep_summary["sweep_dir_path"]
         sweep_summary["results"] = []
         combinations = sweep_summary["combinations"]
         n_combs = len(combinations)
         for comb_idx in range(n_combs):
-            comb_dir_name = sweep_summary["comb_dir_names"][comb_idx]
-            comb_params = sweep_summary["comb_params"][comb_idx]
             self.log("Running combination %02d/%02d" % (comb_idx + 1, n_combs), 0)
             comb_dir_name = sweep_summary["comb_dir_names"][comb_idx]
             comb_params = sweep_summary["comb_params"][comb_idx]
-            self.log("Running combination %02d/%02d" % (comb_idx + 1, n_combs), 0)
             self.params = comb_params
             output_dir = self.segment_rois(
                 output_dir_name=comb_dir_name,
@@ -1011,13 +999,6 @@ class Job:
             parent_dir_name=segmentation_dir_tag,
             info_use_idx=None,
         )
-        rois_dir_path = self.combine_patches(
-            patches_to_segment,
-            rois_dir_path,
-            parent_dir_name=segmentation_dir_tag,
-            info_use_idx=None,
-        )
-
         return rois_dir_path
 
     def compute_npil_masks(self, stats_dir):

--- a/suite3d/reference_image.py
+++ b/suite3d/reference_image.py
@@ -874,7 +874,9 @@ def get_reference_img_cpu(
             refs_f[z] = phasecorr_ref(refImg[z, :, :].squeeze(), smooth_sigma=1.15)
 
         # mask is applied in rigid_2d_reg_cpu
-        tmp, ymax[iter], xmax[iter], cmax[iter] = reg.rigid_2d_reg_cpu(
+        # this will only return mov_shifted, ymaxs, xmaxs
+        # tmp, ymax[iter], xmax[iter], cmax[iter] = reg.rigid_2d_reg_cpu(
+        tmp, ymax[iter], xmax[iter] = reg.rigid_2d_reg_cpu(
             frames,
             mult_mask,
             add_mask,

--- a/suite3d/reference_image.py
+++ b/suite3d/reference_image.py
@@ -838,16 +838,16 @@ def get_reference_img_cpu(
         The first dimension is iteration number, the second is plane number. The value is the frames
         used for the reference iamge in that iteration and plane.
     """
-    ncc = max_reg_xy * 2 + 1
+    ncc = max_reg_xy * 2 + 1 # unused?
+
+    refImg = init_ref_3d(frames)
+    nz, ny, nx = refImg.shape
 
     # Allows rmins/rmaxs to be None, need as list of None
     if rmins is None and rmaxs is None:
         rmins = [None for i in range(nz)]
         rmaxs = [None for i in range(nz)]
 
-    refImg = init_ref_3d(frames)
-
-    nz, ny, nx = refImg.shape
     # Get the computed masks, once.. as its the same for thesame shape of array.. save time...
     # mask_offset need toupdate to refimg, so cal seeratley
     mult_mask, add_mask = compute_masks3D(refImg, sigma)

--- a/suite3d/utils.py
+++ b/suite3d/utils.py
@@ -975,6 +975,11 @@ def estimate_crosstalk(
     time_init = time.time()
 
     nz = im3d.shape[0]  # if you are not ussing all pleans from the second caivty
+
+    if nz <= cavity_size:
+        raise ValueError("Number of z-planes must be greater than or equal to cavity_size."
+                         " Check init-pass parameters `cavity_size`.")
+
     n_second_cavity_planes = nz - cavity_size
 
     steps = n.arange(0, max_test_ct, step_dist)


### PR DESCRIPTION
# WIP: bugfixes, suggestions/ideas

## bugfixes
- [x] `nz` referenced before assignment in `get_reference_img_cpu()`
- [x] Fix `nonrigid` boolean parameter used as function
- [x] Not enough values to unpack `get_reference_img_cpu()`
- [x] Removed a bunch of duplicate segments/variables
- [ ] `KeyError` when segmenting with reconstructed SVD 

## tifffile overhead

``` python
todo("imread from tifffile has an overhead of ~20-30 seconds before it actually reads the file? Can we speed this up?")
tiffile = tifffile.imread(path)
```

I believe the cause of this is tifffile first reading every page in the tiff to get the number of pages, or page offsets.

In older (not sure what year) ScanImage tiff metadata, each file had a "number of frames" section that held the total number of frames in the entire session. Now, it holds the n_frames per tiff file. I believe could be used with TiffFile("file.tiff").asarray(key=frames) to skip the `seek` that is done on every page and immediately extract image data. But this would only work for newer versions of ScanImage.

I have some code I can test with this in the future.

## other suggestions

The parameters that handle channel numbers, i.e. `planes` and `n_ch_tif` could be retrieved from the metadata. 

## bugs

If I run `job.register_gpu()` from Pycharm, not vscode, I get:

``` python
  File "C:\Users\RBO\miniforge3\envs\suite3d-test\lib\site-packages\cupy\cuda\compiler.py", line 376, in compile_using_nvcc
    raise cex
cupy.cuda.compiler.CompileException: `nvcc` command returns non-zero exit status. 
command: ['C:\\Program', 'Files\\NVIDIA', 'GPU', 'Computing', 'Toolkit\\CUDA\\v12.6\\bin\\nvcc.EXE', '-gencode=arch=compute_86,code=sm_86', '--ptx', '--std=c++11', '-IC:\\Users\\RBO\\miniforge3\\envs\\suite3d-test\\lib\\site-packages\\cupy\\_core\\include', '-IC:\\Users\\RBO\\miniforge3\\envs\\suite3d-test\\lib\\site-packages\\cupy\\_core\\include\\cupy\\_cuda\\cuda-12', '-IC:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.6\\include', '-ftz=true', 'C:\\Users\\RBO\\AppData\\Local\\Temp\\tmppg4xeqou\\preprocess.cu']
return-code: 1
stdout/stderr: 
nvcc fatal   : Cannot find compiler 'cl.exe' in PATH
```

A few parameter key errors, probably best to fix with asserts to check they are set in the default params:
``` python 
F_roi, F_neu = ext.extract_activity(..., min_npil_npix=self.params["min_npil_npix"], ...)
KeyError: 'npil_to_roi_npix_ratio'
```

``` python
KeyError: 'segmentation_timebin'
```

Broadcast error during `clip_and_mask` during gpu reg, `mov *= mult_mask`:

``` python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[18], line 1
----> 1 job.register_gpu()
File c:\Users\RBO\repos\suite3d\suite3d\register_gpu.py:271, in clip_and_mask_mov(mov, rmin, rmax, mult_mask, add_mask, cp)
--> 271     if mult_mask is not None: mov *= mult_mask
    272     if add_mask is not None:  mov += add_mask
    273     return mov
ValueError: operands could not be broadcast together with shapes (10, 561, 452) (561, 453) (10, 561, 452)
```